### PR TITLE
Support counting

### DIFF
--- a/src/main/java/nl/kb/xml/transformassert/TransformAssertWithTransformResult.java
+++ b/src/main/java/nl/kb/xml/transformassert/TransformAssertWithTransformResult.java
@@ -11,6 +11,7 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -119,7 +120,7 @@ public class TransformAssertWithTransformResult implements TransformResults {
         return this;
     }
 
-    private TransformAssertWithTransformResult matchXPath(String xPath, String expected, boolean negate, String... rule)
+    private TransformAssertWithTransformResult matchXPath(String xPath, Object expected, boolean negate, String... rule)
             throws XPathExpressionException {
 
         final String report = LogUtil.mkRule(
@@ -132,13 +133,16 @@ public class TransformAssertWithTransformResult implements TransformResults {
             return this;
         }
 
-        final List<String> stringResult = xpathEvaluator.getXpathResult(xPath);
-        if (stringResult.contains(expected) == negate) {
-            final String actual = stringResult.size() == 1
-                    ? stringResult.get(0)
-                    : stringResult.size() == 0
+        final List<Object> xpathResult = expected instanceof Integer
+                ? xpathEvaluator.getXpathResult(xPath, XPathConstants.NUMBER)
+                : xpathEvaluator.getXpathResult(xPath);
+
+        if (xpathResult.contains(expected) == negate) {
+            final String actual = xpathResult.size() == 1
+                    ? "" + xpathResult.get(0)
+                    : xpathResult.size() == 0
                     ? ""
-                    : "any of: " + stringResult;
+                    : "any of: " + xpathResult;
             errors.add(new AssertionError(String.format(
                     report + System.lineSeparator() +
                             "  Expected xpath %s%sto match: '%s'" + System.lineSeparator() +
@@ -163,7 +167,7 @@ public class TransformAssertWithTransformResult implements TransformResults {
      * @return instance of self exposing assertion methods and {@link #evaluate()}
      * @throws XPathExpressionException when the xpath is not valid, or namespace is not declared in {@link #usingNamespace(String, String)}
      */
-    public TransformAssertWithTransformResult hasXpathContaining(String xPath, String expected, String... rule)
+    public TransformAssertWithTransformResult hasXpathContaining(String xPath, Object expected, String... rule)
             throws XPathExpressionException {
 
         return matchXPath(xPath, expected, false, rule);
@@ -358,6 +362,5 @@ public class TransformAssertWithTransformResult implements TransformResults {
 
         logBack.accept(System.lineSeparator() + "IT SHOULD:");
     }
-
 
 }

--- a/src/main/java/nl/kb/xml/transformassert/TransformAssertWithTransformResult.java
+++ b/src/main/java/nl/kb/xml/transformassert/TransformAssertWithTransformResult.java
@@ -247,7 +247,7 @@ public class TransformAssertWithTransformResult implements TransformResults {
      * @return instance of self exposing assertion methods and {@link #evaluate()}
      * @throws XPathExpressionException when the xpath is not valid, or namespace is not declared in {@link #usingNamespace(String, String)}
      */
-    public TransformAssertWithTransformResult andHasXpathContaining(String xPath, String expected, String... rule) throws XPathExpressionException {
+    public TransformAssertWithTransformResult andHasXpathContaining(String xPath, Object expected, String... rule) throws XPathExpressionException {
 
         return hasXpathContaining(xPath, expected, rule);
     }

--- a/src/main/java/nl/kb/xml/transformassert/TransformAssertWithTransformResult.java
+++ b/src/main/java/nl/kb/xml/transformassert/TransformAssertWithTransformResult.java
@@ -4,7 +4,6 @@ import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamSource;

--- a/src/main/java/nl/kb/xml/transformassert/TransformCompareWithTransformResults.java
+++ b/src/main/java/nl/kb/xml/transformassert/TransformCompareWithTransformResults.java
@@ -223,8 +223,8 @@ public class TransformCompareWithTransformResults implements TransformResults {
      * @throws XPathExpressionException when the xpath is not valid, or namespace is not declared in {@link #usingNamespace(String, String)}
      */
     public TransformCompareWithTransformResults hasMatchingXPathResultsFor(String xPath, String... rule) throws XPathExpressionException {
-        final List<String> stringResults;
-        final List<String> expected;
+        final List<Object> xpathResults;
+        final List<Object> expected;
 
         try {
             baselineEvaluator.loadDocument();
@@ -240,31 +240,31 @@ public class TransformCompareWithTransformResults implements TransformResults {
             return this;
         }
 
-        stringResults = resultEvaluator.getXpathResult(xPath);
+        xpathResults = resultEvaluator.getXpathResult(xPath);
         expected = baselineEvaluator.getXpathResult(xPath);
 
 
-        if (stringResults.size() > expected.size()) {
+        if (xpathResults.size() > expected.size()) {
             errors.add(new AssertionError("MATCH XPATH " + xPath + String.format(
                     System.lineSeparator() +
                             "  Expected xpath %s to result in: %d items" + System.lineSeparator() +
                             "  But got: %d items" + System.lineSeparator()
-                    , xPath, expected.size(), stringResults.size()
+                    , xPath, expected.size(), xpathResults.size()
             )));
         }
 
 
-        for (String expectedResult : expected) {
+        for (Object expectedResult : expected) {
             final String report = LogUtil.mkRule(
                     "MATCH XPATH " + xPath + "='" + expectedResult + "'"
                     , rule);
 
-            if (!stringResults.contains(expectedResult)) {
-                final String actual = stringResults.size() == 1
-                        ? stringResults.get(0)
-                        : stringResults.size() == 0
+            if (!xpathResults.contains(expectedResult)) {
+                final String actual = xpathResults.size() == 1
+                        ? "" + xpathResults.get(0)
+                        : xpathResults.size() == 0
                         ? ""
-                        : "any of: " + stringResults;
+                        : "any of: " + xpathResults;
 
 
                 errors.add(new AssertionError(report + String.format(

--- a/src/main/java/nl/kb/xml/transformassert/XpathEvaluator.java
+++ b/src/main/java/nl/kb/xml/transformassert/XpathEvaluator.java
@@ -6,6 +6,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import javax.xml.namespace.NamespaceContext;
+import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -49,7 +50,11 @@ class XpathEvaluator {
         namespaces.put(key, value);
     }
 
-    List<String> getXpathResult(String xPath) throws XPathExpressionException {
+    List<Object> getXpathResult(String xPath) throws XPathExpressionException {
+        return getXpathResult(xPath, XPathConstants.NODESET);
+    }
+
+    List<Object> getXpathResult(String xPath, QName type) throws XPathExpressionException {
 
         final XPath xpath = xPathFactory.newXPath();
 
@@ -77,10 +82,15 @@ class XpathEvaluator {
         }
 
         final XPathExpression expression = xpath.compile(xPath);
-        final NodeList nodes = (NodeList) expression.evaluate(doc, XPathConstants.NODESET);
-        final List<String> result = new ArrayList<>();
-        for (int i = 0; i < nodes.getLength(); i++) {
-            result.add(nodes.item(i).getTextContent().trim());
+        final Object xpathResult = expression.evaluate(doc, type);
+        final List<Object> result = new ArrayList<>();
+        if (xpathResult instanceof NodeList) {
+            final NodeList nodes = (NodeList) xpathResult;
+            for (int i = 0; i < nodes.getLength(); i++) {
+                result.add(nodes.item(i).getTextContent().trim());
+            }
+        } else if (xpathResult instanceof Double) {
+            result.add(((Double) xpathResult).intValue());
         }
 
         return result;

--- a/src/test/java/nl/kb/xml/transformasserttests/TransformAssertTest.java
+++ b/src/test/java/nl/kb/xml/transformasserttests/TransformAssertTest.java
@@ -333,4 +333,12 @@ public class TransformAssertTest {
                 .hasXpathContaining("/root/foo/text()", "bar")
                 .evaluate();
     }
+
+    @Test
+    public void supportsCountAssertions() throws XPathExpressionException, UnsupportedEncodingException {
+        describeXml(XML.getBytes())
+                .hasXpathContaining("count(/root/foo)", 1)
+                .evaluate();
+    }
+
 }


### PR DESCRIPTION
Fixes #1
Changes signature of ```TransformAssertWithTransformResult#hasXpathContaining``` and ```TransformAssertWithTransformResult#andHasXpathContaining``` to receive ```Object``` as second parameter. When passed ```Object instanceof Integer``` expect the xpath evaluation to return a ```XPathConstants.NUMBER````.